### PR TITLE
Update pid:tostring function to reflect the real state

### DIFF
--- a/posix/spawn.c
+++ b/posix/spawn.c
@@ -192,11 +192,17 @@ int process_kill(lua_State *L)
   return 1;
 }
 
+
 /* proc -- string */
 int process_tostring(lua_State *L)
 {
   struct process *p = luaL_checkudata(L, 1, PROCESS_HANDLE);
   char buf[40];
+  int status=0;
+  int res;
+  res=waitpid(p->pid, &status, WNOHANG);
+  if( p->pid == res ) p->status=WEXITSTATUS(status);
+  else if(res == -1) p->status=0;
   lua_pushlstring(L, buf,
     sprintf(buf, "process (%lu, %s)", (unsigned long)p->pid,
       p->status==-1 ? "running" : "terminated"));

--- a/w32api/spawn.c
+++ b/w32api/spawn.c
@@ -231,13 +231,12 @@ int process_tostring(lua_State *L)
 {
   struct process *p = luaL_checkudata(L, 1, PROCESS_HANDLE);
   char buf[40];
-  int status=0;
-  int res;
-  res=waitpid(p->pid, &status, WNOHANG);
-  if( p->pid == res ) p->status=WEXITSTATUS(status);
-  else if(res == -1) p->status=0;
+  DWORD exitcode;
+  if( !GetExitCodeProcess(p->hProcess, &exitcode))
+    return windows_pushlasterror(L);
+  p->status = ( exitcode == STILL_ACTIVE ) ? -1 : 0;
   lua_pushlstring(L, buf,
-    sprintf(buf, "process (%lu, %s)", (unsigned long)p->pid,
+    sprintf(buf, "process (%lu, %s)", (unsigned long)p->dwProcessId,
       p->status==-1 ? "running" : "terminated"));
   return 1;
 }

--- a/w32api/spawn.c
+++ b/w32api/spawn.c
@@ -225,13 +225,19 @@ int process_kill(lua_State *L)
   return 1;
 }
 
+
 /* proc -- string */
 int process_tostring(lua_State *L)
 {
   struct process *p = luaL_checkudata(L, 1, PROCESS_HANDLE);
   char buf[40];
+  int status=0;
+  int res;
+  res=waitpid(p->pid, &status, WNOHANG);
+  if( p->pid == res ) p->status=WEXITSTATUS(status);
+  else if(res == -1) p->status=0;
   lua_pushlstring(L, buf,
-    sprintf(buf, "process (%lu, %s)", (unsigned long)p->dwProcessId,
+    sprintf(buf, "process (%lu, %s)", (unsigned long)p->pid,
       p->status==-1 ? "running" : "terminated"));
   return 1;
 }


### PR DESCRIPTION
I wrote this patch quite a while ago for LuaDist - it´s pretty useful if you want to (periodically) check if a launched process is still alive...
